### PR TITLE
chore: enable Renovate platformAutomerge and GH Actions manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
     "schedule:weekly",
     ":semanticCommits"
   ],
+  "platformAutomerge": true,
   "packageRules": [
     {
       "matchManagers": ["gomod"],
@@ -28,6 +29,18 @@
       "matchPackageNames": ["github.com/hashicorp/terraform-json"],
       "automerge": false,
       "labels": ["terraform-compat"]
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "labels": ["github-actions"]
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["major"],
+      "automerge": false,
+      "labels": ["github-actions"]
     }
   ],
   "postUpdateOptions": ["gomodTidy"],


### PR DESCRIPTION
## Summary
- Add `platformAutomerge: true` to `renovate.json` for GitHub native auto-merge
- Add GitHub Actions manager rules for CI action updates

## Test plan
- [ ] Verify Renovate picks up config after app installation
- [ ] Confirm auto-merge works on minor/patch updates

Generated with [Claude Code](https://claude.com/claude-code)