### PR TITLE
build: use go-version-file and add Renovate for Go toolchain management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.13'
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Download dependencies
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.13'
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Run golangci-lint
@@ -79,7 +79,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.13'
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Build binary
@@ -105,7 +105,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.13'
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Run govulncheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Run tests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/larsenclose/oci-tf-bootstrap
 
-go 1.24.0
+go 1.24.13
 
 require (
 	github.com/oracle/oci-go-sdk/v65 v65.105.2

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,9 @@
     "schedule:weekly",
     ":semanticCommits"
   ],
+  "golang": {
+    "enabled": true
+  },
   "platformAutomerge": true,
   "packageRules": [
     {


### PR DESCRIPTION
## Summary
- Update `go` directive in go.mod from `1.24.0` to `1.24.13` for precise patch pinning
- Replace all hardcoded `go-version: '1.24.13'` / `go-version: '1.24'` in CI workflows with `go-version-file: 'go.mod'` so CI tracks go.mod as the single source of truth
- Add `golang.enabled: true` to renovate.json to enable Renovate's Go toolchain update detection

## Test plan
- [x] `go build .` passes locally
- [x] `go test ./...` passes locally (2 packages)
- [x] `go mod tidy` produces no diff