### PR TITLE
ci: add gofmt check and go mod tidy verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,14 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
+      - name: Check formatting
+        run: |
+          if [ -n "$(gofmt -l .)" ]; then
+            echo "Files not formatted:"
+            gofmt -l .
+            exit 1
+          fi
+
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:


### PR DESCRIPTION
Adds explicit gofmt formatting check to the lint job. The go mod tidy drift check was already present in the test job.